### PR TITLE
Fix RedNode navigation links and session script

### DIFF
--- a/rednode.html
+++ b/rednode.html
@@ -204,8 +204,8 @@
       or power up your node network from one command center.
     </p>
     <div class="starter-buttons">
-      <a href="index.html" title="Open the RedNode chat dashboard">Chat</a>
-      <a href="/ex1/index.html" title="Start the Extream live stream" target="_blank" rel="noopener">Stream</a>
+      <a href="./index.html" title="Open the RedNode chat dashboard">Chat</a>
+      <a href="./ex1/index.html" title="Start the Extream live stream" target="_blank" rel="noopener">Stream</a>
       <a href="#nodes" title="Explore the RedNode system">Node On</a>
     </div>
   </section>
@@ -325,6 +325,6 @@
   <footer>
     <p>&copy; 2025 RedNode.ai. All Rights Reserved.</p>
   </footer>
-  <script src="{{ url_for('static', filename='session.js') }}"></script>
+  <script src="./static/session.js"></script>
 </body>
 </html>

--- a/static/session.js
+++ b/static/session.js
@@ -11,9 +11,34 @@
     if(saved){
       try{ Object.assign(context, JSON.parse(saved)); } catch {}
     }
+    const container = document.querySelector('[data-chat-container]') || document.body;
+    const buildButton = () => {
+      if(typeof window.createIconButton === 'function'){
+        return window.createIconButton('chat-toggle-btn', '/static/chat.svg');
+      }
+      const btn = document.createElement('button');
+      btn.id = 'chat-toggle-btn';
+      btn.type = 'button';
+      btn.textContent = 'Chat';
+      Object.assign(btn.style, {
+        position: 'fixed',
+        bottom: '20px',
+        right: '20px',
+        padding: '10px 14px',
+        background: '#b30000',
+        color: '#ffd700',
+        border: '2px solid #ffd700',
+        borderRadius: '12px',
+        cursor: 'pointer',
+        zIndex: 1000
+      });
+      return btn;
+    };
     if(context.username){
-      const chatBtn = createIconButton('chat-toggle-btn', '/static/chat.svg');
-      container.appendChild(chatBtn);
+      const chatBtn = buildButton();
+      if(container && chatBtn && !document.getElementById('chat-toggle-btn')){
+        container.appendChild(chatBtn);
+      }
       // Inject live chat for logged-in users
       const sio = document.createElement('script');
       // Load Socket.IO client from the official CDN


### PR DESCRIPTION
## Summary
- update RedNode Extream Starter links so they point to the live chat and stream dashboards
- replace the Flask-only static script reference with a relative asset path
- harden the session bootstrap script with fallbacks so it no longer throws when helper utilities are absent

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68cad9342758833397aa0dcd276b6a6c