### PR TITLE
Point control center to Exstream

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -427,7 +427,7 @@
         <a
           class="chip fun-btn"
           id="extream-link"
-          href="ex1/index.html"
+          href="https://exstream.onrender.com/"
           target="_blank"
           rel="noopener"
           title="Open the Extream Chatbase channel"

--- a/rednode.html
+++ b/rednode.html
@@ -177,7 +177,7 @@
       <img src="static/excavator.svg" alt="RedNode dashboard icon" loading="lazy">
       <span>Back to Dashboard</span>
     </button>
-    <button type="button" class="nav-button" onclick="window.location.href='index.html'">
+    <button type="button" class="nav-button" onclick="window.location.href='https://exstream.onrender.com/'">
       <img src="static/excavator.svg" alt="Excavator layout icon" loading="lazy">
       <span>Launch Excavator Control Center</span>
     </button>


### PR DESCRIPTION
## Summary
- update the Excavator Control Center launch button on the marketing page to open the Exstream site
- point the dashboard's Extream shortcut directly to https://exstream.onrender.com/

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68caf6724e6c833386bb5c44a5b74ad2