### PR TITLE
Set home page as default entry point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 FROM nginx:alpine
 
 # Copy the landing page and static assets to the container's web root
-COPY rednode.html /usr/share/nginx/html/index.html
+COPY home.html /usr/share/nginx/html/index.html
+COPY home.html /usr/share/nginx/html/home.html
 COPY rednode.html /usr/share/nginx/html/rednode.html
 COPY live/ /usr/share/nginx/html/live/
 COPY static/ /usr/share/nginx/html/static/


### PR DESCRIPTION
## Summary
- update the container image so that home.html is served as the root page
- keep copies of both home.html and rednode.html available under predictable paths

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cb102bc6b08333965cfced0cb466da