### PR TITLE
Fix EX button link to internal live experience

### DIFF
--- a/rednode.html
+++ b/rednode.html
@@ -185,7 +185,7 @@
   </nav>
 
   <div class="nav-buttons" aria-label="Quick navigation">
-    <button type="button" class="nav-button" onclick="window.open('https://excavator-game.onrender.com', '_blank')">
+    <button type="button" class="nav-button" onclick="window.open('/live/', '_blank')">
       <img src="static/excavator.svg" alt="RedNode dashboard icon" loading="lazy">
       <span>Play Ex-Air</span>
     </button>


### PR DESCRIPTION
## Summary
- update the Ex-Air navigation button so it opens the on-site /live/ experience instead of an unavailable external Render domain

## Testing
- not run (static link update)


------
https://chatgpt.com/codex/tasks/task_b_68cb1d297eb08333bdc71bf459c6bfd7