### PR TITLE
Add token sale fallback when contract missing

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="rednode-token-mint" content="So11111111111111111111111111111111111111112" />
   <meta name="rednode-rpc-url" content="https://api.mainnet-beta.solana.com" />
+  <meta name="rednode-sale-url" content="home.html#marketplace" />
     <title>RedNode Excavation</title>
     <link rel="icon" href="static/excavator.svg" />
   <meta name="color-scheme" content="dark light" />

--- a/home.html
+++ b/home.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="rednode-token-mint" content="So11111111111111111111111111111111111111112">
   <meta name="rednode-rpc-url" content="https://api.mainnet-beta.solana.com">
+  <meta name="rednode-sale-url" content="home.html#marketplace">
   <title>RedNode.ai – Integrated Intelligent Node System</title>
   <style>
     * {

--- a/live/index.html
+++ b/live/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="rednode-token-mint" content="So11111111111111111111111111111111111111112" />
   <meta name="rednode-rpc-url" content="https://api.mainnet-beta.solana.com" />
+  <meta name="rednode-sale-url" content="home.html#marketplace" />
     <title>RedNode Excavation</title>
     <link rel="icon" href="/static/excavator.svg" />
   <meta name="color-scheme" content="dark light" />

--- a/rednode.html
+++ b/rednode.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="rednode-token-mint" content="So11111111111111111111111111111111111111112">
   <meta name="rednode-rpc-url" content="https://api.mainnet-beta.solana.com">
+  <meta name="rednode-sale-url" content="home.html#marketplace">
   <title>RedNode.ai – Integrated Intelligent Node System</title>
   <style>
     * {


### PR DESCRIPTION
## Summary
- add sale URL support to the wallet configuration and track the configured mint contract state on startup
- block wallet gating when the mint account is missing by surfacing a token sale CTA and persisting the new status handling
- surface the sale URL metadata on the main HTML entry points so clients can direct users to the marketplace

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cea94417f48333956f16b3be2cefbc