### PR TITLE
Add wallet verification gate before accessing live controls

### DIFF
--- a/home.html
+++ b/home.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>RedNode.ai – Integrated Intelligent Node System</title>
+  <link rel="stylesheet" href="static/wallet-gate.css">
   <style>
     * {
       margin: 0;
@@ -126,7 +127,7 @@
     }
   </style>
 </head>
-<body>
+<body class="wallet-locked">
   <nav>
     <ul>
       <li><a href="#home">Home</a></li>
@@ -264,6 +265,32 @@
   <footer>
     <p>&copy; 2025 RedNode.ai. All Rights Reserved.</p>
   </footer>
+  <div id="wallet-gate" role="dialog" aria-modal="true" aria-labelledby="wallet-gate-title" data-token-address="" data-token-min="">
+    <div class="wallet-card">
+      <h2 id="wallet-gate-title">Connect Your Wallet</h2>
+      <p>Select your Ethereum wallet and verify your token ownership to unlock the live controls.</p>
+      <div class="wallet-status">Wallet access required.</div>
+      <div class="wallet-actions">
+        <button type="button" data-action="connect">Connect Wallet</button>
+        <p class="wallet-connected" aria-live="polite">Connected as <strong id="wallet-connected-account">—</strong></p>
+      </div>
+      <label for="wallet-token-address">
+        Token contract address
+        <input type="text" id="wallet-token-address" name="wallet-token-address" placeholder="0x…" autocomplete="off">
+      </label>
+      <label for="wallet-token-amount">
+        Minimum balance required (optional)
+        <input type="number" id="wallet-token-amount" name="wallet-token-amount" min="0" step="any" placeholder="e.g. 10">
+      </label>
+      <div class="wallet-actions">
+        <button type="button" data-action="verify" disabled>Verify Token</button>
+        <small><a href="#" data-action="reset">Reset access</a> to switch wallets.</small>
+      </div>
+      <p class="wallet-message" aria-live="polite"></p>
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/ethers@6.8.1/dist/ethers.min.js" integrity="sha384-4Mi1Wd9msMhyiEKkQ9GBcoxiTqUbFVG71EZrKT9x/93Rl5wiNhcMD4Hn9TP0EQLU" crossorigin="anonymous"></script>
+  <script src="static/wallet-gate.js"></script>
   <script src="{{ url_for('static', filename='session.js') }}"></script>
 </body>
 </html>

--- a/live/index.html
+++ b/live/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>RedNode Excavation</title>
     <link rel="icon" href="/static/excavator.svg" />
+    <link rel="stylesheet" href="/static/wallet-gate.css" />
   <meta name="color-scheme" content="dark light" />
   <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
   <style>
@@ -404,7 +405,7 @@
     }
   </style>
 </head>
-<body>
+<body class="wallet-locked">
   <div class="wrap">
     <header>
       <div class="brand">
@@ -1700,5 +1701,31 @@
     requireAuth();
   })();
   </script>
+  <div id="wallet-gate" role="dialog" aria-modal="true" aria-labelledby="wallet-gate-title" data-token-address="" data-token-min="">
+    <div class="wallet-card">
+      <h2 id="wallet-gate-title">Connect Your Wallet</h2>
+      <p>Verify your token ownership to begin streaming and control sessions.</p>
+      <div class="wallet-status">Wallet access required.</div>
+      <div class="wallet-actions">
+        <button type="button" data-action="connect">Connect Wallet</button>
+        <p class="wallet-connected" aria-live="polite">Connected as <strong id="wallet-connected-account">—</strong></p>
+      </div>
+      <label for="wallet-token-address">
+        Token contract address
+        <input type="text" id="wallet-token-address" name="wallet-token-address" placeholder="0x…" autocomplete="off">
+      </label>
+      <label for="wallet-token-amount">
+        Minimum balance required (optional)
+        <input type="number" id="wallet-token-amount" name="wallet-token-amount" min="0" step="any" placeholder="e.g. 10">
+      </label>
+      <div class="wallet-actions">
+        <button type="button" data-action="verify" disabled>Verify Token</button>
+        <small><a href="#" data-action="reset">Reset access</a> to switch wallets.</small>
+      </div>
+      <p class="wallet-message" aria-live="polite"></p>
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/ethers@6.8.1/dist/ethers.min.js" integrity="sha384-4Mi1Wd9msMhyiEKkQ9GBcoxiTqUbFVG71EZrKT9x/93Rl5wiNhcMD4Hn9TP0EQLU" crossorigin="anonymous"></script>
+  <script src="/static/wallet-gate.js"></script>
 </body>
 </html>

--- a/rednode.html
+++ b/rednode.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>RedNode.ai – Integrated Intelligent Node System</title>
+  <link rel="stylesheet" href="/static/wallet-gate.css">
   <style>
     * {
       margin: 0;
@@ -172,7 +173,7 @@
     }
   </style>
 </head>
-<body>
+<body class="wallet-locked">
   <nav>
     <ul>
       <li><a href="#home">Home</a></li>
@@ -285,5 +286,31 @@
   <footer>
     <p>&copy; 2025 RedNode Excavation. All Rights Reserved.</p>
   </footer>
+  <div id="wallet-gate" role="dialog" aria-modal="true" aria-labelledby="wallet-gate-title" data-token-address="" data-token-min="">
+    <div class="wallet-card">
+      <h2 id="wallet-gate-title">Connect Your Wallet</h2>
+      <p>Select your Ethereum wallet and verify your token ownership to unlock live excavation controls.</p>
+      <div class="wallet-status">Wallet access required.</div>
+      <div class="wallet-actions">
+        <button type="button" data-action="connect">Connect Wallet</button>
+        <p class="wallet-connected" aria-live="polite">Connected as <strong id="wallet-connected-account">—</strong></p>
+      </div>
+      <label for="wallet-token-address">
+        Token contract address
+        <input type="text" id="wallet-token-address" name="wallet-token-address" placeholder="0x…" autocomplete="off">
+      </label>
+      <label for="wallet-token-amount">
+        Minimum balance required (optional)
+        <input type="number" id="wallet-token-amount" name="wallet-token-amount" min="0" step="any" placeholder="e.g. 10">
+      </label>
+      <div class="wallet-actions">
+        <button type="button" data-action="verify" disabled>Verify Token</button>
+        <small><a href="#" data-action="reset">Reset access</a> to switch wallets.</small>
+      </div>
+      <p class="wallet-message" aria-live="polite"></p>
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/ethers@6.8.1/dist/ethers.min.js" integrity="sha384-4Mi1Wd9msMhyiEKkQ9GBcoxiTqUbFVG71EZrKT9x/93Rl5wiNhcMD4Hn9TP0EQLU" crossorigin="anonymous"></script>
+  <script src="/static/wallet-gate.js"></script>
 </body>
 </html>

--- a/static/wallet-gate.css
+++ b/static/wallet-gate.css
@@ -1,0 +1,141 @@
+body.wallet-locked {
+  overflow: hidden;
+}
+
+#wallet-gate {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 0, 0, 0.88);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 3000;
+  transition: opacity 0.25s ease;
+}
+
+#wallet-gate.wallet-gate-hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+#wallet-gate .wallet-card {
+  width: min(420px, 100%);
+  border-radius: 18px;
+  padding: 2.25rem 2rem;
+  background: linear-gradient(160deg, rgba(120, 0, 0, 0.92), rgba(30, 0, 0, 0.9));
+  border: 2px solid rgba(255, 215, 0, 0.8);
+  color: #fffbec;
+  box-shadow: 0 0 28px rgba(255, 215, 0, 0.35), 0 14px 24px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+#wallet-gate .wallet-card h2 {
+  font-size: 1.75rem;
+  margin: 0;
+  text-align: center;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  color: #ffe06b;
+}
+
+#wallet-gate .wallet-card p {
+  margin: 0;
+  line-height: 1.5;
+  color: rgba(255, 245, 200, 0.92);
+  text-align: center;
+}
+
+#wallet-gate .wallet-card label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: rgba(255, 240, 200, 0.95);
+}
+
+#wallet-gate .wallet-card input[type="text"],
+#wallet-gate .wallet-card input[type="number"] {
+  width: 100%;
+  padding: 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 215, 0, 0.65);
+  background: rgba(40, 0, 0, 0.85);
+  color: #fffce6;
+  font-size: 0.95rem;
+  box-shadow: inset 0 0 10px rgba(255, 215, 0, 0.18);
+}
+
+#wallet-gate .wallet-card input::placeholder {
+  color: rgba(255, 215, 0, 0.45);
+}
+
+#wallet-gate .wallet-card button {
+  padding: 0.85rem 1.2rem;
+  border-radius: 999px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border: 2px solid rgba(255, 215, 0, 0.9);
+  background: radial-gradient(circle at top, #ff004c, #b30000 55%, #530000 100%);
+  color: #fff8d6;
+  cursor: pointer;
+  box-shadow: 0 0 16px rgba(255, 0, 76, 0.45), inset 0 0 12px rgba(255, 215, 0, 0.55);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+#wallet-gate .wallet-card button:hover,
+#wallet-gate .wallet-card button:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 0 24px rgba(255, 0, 76, 0.65), inset 0 0 14px rgba(255, 215, 0, 0.7);
+}
+
+#wallet-gate .wallet-card button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+  box-shadow: none;
+}
+
+#wallet-gate .wallet-status,
+#wallet-gate .wallet-connected {
+  font-size: 0.9rem;
+  text-align: center;
+  color: rgba(255, 245, 215, 0.92);
+}
+
+#wallet-gate .wallet-status strong,
+#wallet-gate .wallet-connected strong {
+  color: #ffe573;
+}
+
+#wallet-gate .wallet-message {
+  min-height: 1.2rem;
+  text-align: center;
+  font-size: 0.9rem;
+  color: #ffefaa;
+}
+
+#wallet-gate .wallet-message.error {
+  color: #ff9d9d;
+}
+
+#wallet-gate .wallet-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+#wallet-gate .wallet-card small {
+  color: rgba(255, 230, 180, 0.8);
+  text-align: center;
+}
+
+@media (max-width: 520px) {
+  #wallet-gate .wallet-card {
+    padding: 1.75rem 1.5rem;
+  }
+}

--- a/static/wallet-gate.js
+++ b/static/wallet-gate.js
@@ -1,0 +1,307 @@
+(function(){
+  const STORAGE_KEY = 'rednode_wallet_gate';
+  const overlay = document.getElementById('wallet-gate');
+  if(!overlay){
+    return;
+  }
+
+  const connectBtn = overlay.querySelector('[data-action="connect"]');
+  const verifyBtn = overlay.querySelector('[data-action="verify"]');
+  const resetBtn = overlay.querySelector('[data-action="reset"]');
+  const statusEl = overlay.querySelector('.wallet-status');
+  const messageEl = overlay.querySelector('.wallet-message');
+  const tokenInput = overlay.querySelector('#wallet-token-address');
+  const amountInput = overlay.querySelector('#wallet-token-amount');
+  const accountEl = overlay.querySelector('#wallet-connected-account');
+
+  const presetAddress = overlay.dataset.tokenAddress || '';
+  const presetAmount = overlay.dataset.tokenMin || '';
+
+  let provider = null;
+  let currentAccount = null;
+  let verified = false;
+  let pendingCallback = null;
+  let currentToken = null;
+
+  const saved = loadState();
+  if(saved && saved.account){
+    verified = true;
+    currentAccount = saved.account;
+    currentToken = saved.token || null;
+    if(tokenInput){
+      tokenInput.value = saved.token || presetAddress;
+    }
+    if(amountInput && presetAmount){
+      amountInput.value = presetAmount;
+    }
+    updateStatus(`Access previously granted for <strong>${shorten(saved.account)}</strong>.`);
+    if(accountEl){
+      accountEl.textContent = shorten(saved.account);
+    }
+    hideOverlay();
+  } else {
+    if(tokenInput && presetAddress){
+      tokenInput.value = presetAddress;
+    }
+    if(amountInput && presetAmount){
+      amountInput.value = presetAmount;
+    }
+    showOverlay();
+  }
+
+  function showOverlay(){
+    overlay.classList.remove('wallet-gate-hidden');
+    document.body.classList.add('wallet-locked');
+  }
+
+  function hideOverlay(){
+    overlay.classList.add('wallet-gate-hidden');
+    document.body.classList.remove('wallet-locked');
+  }
+
+  function shorten(address){
+    if(!address){
+      return '';
+    }
+    return `${address.slice(0, 6)}…${address.slice(-4)}`;
+  }
+
+  function updateStatus(html){
+    if(statusEl){
+      statusEl.innerHTML = html || '';
+    }
+  }
+
+  function updateMessage(text, isError){
+    if(!messageEl){
+      return;
+    }
+    messageEl.textContent = text || '';
+    messageEl.classList.toggle('error', !!isError);
+  }
+
+  async function ensureProvider(){
+    if(provider){
+      return provider;
+    }
+    if(!window.ethereum){
+      throw new Error('No Ethereum provider detected. Please install MetaMask or a compatible wallet.');
+    }
+    provider = new ethers.BrowserProvider(window.ethereum);
+    return provider;
+  }
+
+  async function connectWallet(){
+    try{
+      updateMessage('Requesting wallet access…');
+      const browserProvider = await ensureProvider();
+      const accounts = await browserProvider.send('eth_requestAccounts', []);
+      if(!accounts || !accounts.length){
+        throw new Error('No accounts returned from wallet.');
+      }
+      currentAccount = ethers.getAddress(accounts[0]);
+      updateStatus(`Connected wallet <strong>${shorten(currentAccount)}</strong>.`);
+      if(accountEl){
+        accountEl.textContent = shorten(currentAccount);
+      }
+      updateMessage('');
+      if(verifyBtn){
+        verifyBtn.disabled = false;
+      }
+      return currentAccount;
+    } catch(err){
+      updateMessage(err.message || 'Failed to connect wallet.', true);
+      throw err;
+    }
+  }
+
+  async function verifyToken(){
+    if(!currentAccount){
+      updateMessage('Please connect your wallet first.', true);
+      return;
+    }
+    const tokenAddress = tokenInput ? tokenInput.value.trim() : '';
+    if(!tokenAddress){
+      updateMessage('Enter the ERC-20 token contract address to verify.', true);
+      return;
+    }
+    if(!ethers.isAddress(tokenAddress)){
+      updateMessage('That token contract address is not valid.', true);
+      return;
+    }
+    try{
+      if(verifyBtn){
+        verifyBtn.disabled = true;
+      }
+      updateMessage('Verifying token balance…');
+      const provider = await ensureProvider();
+      const contract = new ethers.Contract(tokenAddress, [
+        'function balanceOf(address) view returns (uint256)',
+        'function decimals() view returns (uint8)',
+        'function symbol() view returns (string)'
+      ], provider);
+      const [balance, decimals, symbol] = await Promise.all([
+        contract.balanceOf(currentAccount),
+        contract.decimals().catch(() => 18),
+        contract.symbol().catch(() => 'token')
+      ]);
+      const parsedRequirement = parseRequired(amountInput ? amountInput.value.trim() : '', decimals);
+      if(parsedRequirement.error){
+        if(verifyBtn){
+          verifyBtn.disabled = false;
+        }
+        return;
+      }
+      const requiredRaw = parsedRequirement.amount;
+      const hasBalance = requiredRaw === null ? balance > 0n : balance >= requiredRaw;
+      if(!hasBalance){
+        const requiredMsg = requiredRaw === null ? 'any amount' : `${ethers.formatUnits(requiredRaw, decimals)} ${symbol}`;
+        updateMessage(`Balance check failed. You need ${requiredMsg} of this token.`, true);
+        if(verifyBtn){
+          verifyBtn.disabled = false;
+        }
+        return;
+      }
+      const formattedBalance = ethers.formatUnits(balance, decimals);
+      updateMessage(`Verified! Detected ${Number(formattedBalance).toFixed(4)} ${symbol}.`);
+      verified = true;
+      currentToken = tokenAddress;
+      persistState({ account: currentAccount, token: currentToken });
+      hideOverlay();
+      document.dispatchEvent(new CustomEvent('wallet-verified', {
+        detail: { account: currentAccount, token: tokenAddress, balance: formattedBalance, symbol }
+      }));
+      if(typeof pendingCallback === 'function'){
+        pendingCallback();
+        pendingCallback = null;
+      }
+    } catch(err){
+      updateMessage(err.message || 'Unable to verify token balance.', true);
+      if(verifyBtn){
+        verifyBtn.disabled = false;
+      }
+    }
+  }
+
+  function parseRequired(value, decimals){
+    if(!value){
+      return { amount: null, error: false };
+    }
+    try{
+      const trimmed = value.replace(/,/g, '');
+      if(!trimmed){
+        return { amount: null, error: false };
+      }
+      return { amount: ethers.parseUnits(trimmed, decimals), error: false };
+    } catch(err){
+      updateMessage('The required amount could not be parsed. Use a numeric value.', true);
+      return { amount: null, error: true };
+    }
+  }
+
+  function persistState(data){
+    if(!data){
+      localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...data, timestamp: Date.now() }));
+  }
+
+  function loadState(){
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if(!raw){
+      return null;
+    }
+    try{
+      return JSON.parse(raw);
+    } catch(err){
+      return null;
+    }
+  }
+
+  function resetAccess(){
+    persistState(null);
+    verified = false;
+    currentAccount = null;
+    currentToken = null;
+    pendingCallback = null;
+    updateStatus('Wallet access required.');
+    updateMessage('');
+    if(verifyBtn){
+      verifyBtn.disabled = true;
+    }
+    if(accountEl){
+      accountEl.textContent = '—';
+    }
+    if(tokenInput){
+      tokenInput.value = presetAddress || '';
+    }
+    if(amountInput){
+      amountInput.value = presetAmount || '';
+    }
+    showOverlay();
+  }
+
+  if(connectBtn){
+    connectBtn.addEventListener('click', () => {
+      connectWallet().catch(() => {});
+    });
+  }
+
+  if(verifyBtn){
+    verifyBtn.addEventListener('click', () => {
+      verifyToken();
+    });
+  }
+
+  if(resetBtn){
+    resetBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      resetAccess();
+    });
+  }
+
+  if(verifyBtn){
+    verifyBtn.disabled = !currentAccount;
+  }
+
+  const walletGate = {
+    isVerified(){
+      return verified;
+    },
+    requireAccess(callback){
+      if(verified){
+        if(typeof callback === 'function'){
+          callback();
+        }
+        return true;
+      }
+      pendingCallback = typeof callback === 'function' ? callback : null;
+      showOverlay();
+      return false;
+    },
+    reset: resetAccess,
+    get account(){
+      return currentAccount;
+    }
+  };
+
+  window.walletGate = walletGate;
+
+  if(window.ethereum){
+    window.ethereum.on('accountsChanged', (accounts) => {
+      if(!accounts || !accounts.length){
+        resetAccess();
+        return;
+      }
+      currentAccount = ethers.getAddress(accounts[0]);
+      if(verified){
+        persistState({ account: currentAccount, token: currentToken });
+      }
+      updateStatus(`Connected wallet <strong>${shorten(currentAccount)}</strong>.`);
+      if(accountEl){
+        accountEl.textContent = shorten(currentAccount);
+      }
+    });
+  }
+})();


### PR DESCRIPTION
## Summary
- introduce a reusable wallet access overlay that blocks the interface until an Ethereum wallet is connected and a token balance is verified
- apply the wallet verification gate to the home, RedNode control center, and live dashboard pages with shared styling and scripts
- persist verified wallets in localStorage and provide reset handling to allow users to switch accounts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cede8d1f3483339d046f7224b70e6b